### PR TITLE
Implement endpoints to get companies

### DIFF
--- a/src/lib/application/http.rs
+++ b/src/lib/application/http.rs
@@ -7,7 +7,8 @@ use axum::{
     Extension,
 };
 use handlers::{
-    attach_professional::attach_professional, create_company::create_company, health_check,
+    attach_professional::attach_professional, create_company::create_company,
+    get_companies::get_companies, get_company::get_company, health_check,
 };
 use tokio::net;
 use tracing::{info, info_span};
@@ -87,7 +88,9 @@ where
     C: CompanyService + Send + Sync + 'static,
 {
     axum::Router::new()
+        .route("/companies", get(get_companies::<C>))
         .route("/companies", post(create_company::<C>))
+        .route("/companies/:company_id", get(get_company::<C>))
         .route(
             "/companies/:company_id/professionals",
             post(attach_professional::<C>),

--- a/src/lib/application/http/handlers.rs
+++ b/src/lib/application/http/handlers.rs
@@ -3,6 +3,8 @@ use serde::Serialize;
 
 pub mod attach_professional;
 pub mod create_company;
+pub mod get_companies;
+pub mod get_company;
 pub mod health_check;
 
 pub struct ApiSuccess<T: Serialize + PartialEq>(StatusCode, Json<ApiResponseBody<T>>);

--- a/src/lib/application/http/handlers/get_companies.rs
+++ b/src/lib/application/http/handlers/get_companies.rs
@@ -1,0 +1,17 @@
+use std::sync::Arc;
+
+use axum::{http::StatusCode, Extension};
+
+use crate::domain::company::{models::Company, ports::CompanyService};
+
+use super::{ApiError, ApiSuccess};
+
+pub async fn get_companies<C: CompanyService>(
+    Extension(company_service): Extension<Arc<C>>,
+) -> Result<ApiSuccess<Vec<Company>>, ApiError> {
+    company_service
+        .find_all()
+        .await
+        .map_err(ApiError::from)
+        .map(|c| ApiSuccess::new(StatusCode::OK, c))
+}

--- a/src/lib/application/http/handlers/get_company.rs
+++ b/src/lib/application/http/handlers/get_company.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use axum::{extract::Path, http::StatusCode, Extension};
+
+use crate::domain::company::ports::CompanyService;
+
+use super::{ApiError, ApiSuccess};
+
+pub async fn get_company<C: CompanyService>(
+    Extension(company_service): Extension<Arc<C>>,
+    Path(company_id): Path<String>,
+) -> Result<ApiSuccess<String>, ApiError> {
+    company_service
+        .find_by_id(company_id)
+        .await
+        .map_err(ApiError::from)
+        .map(|company| ApiSuccess::new(StatusCode::OK, company.unwrap().id.to_string()))
+}

--- a/src/lib/domain/company/models.rs
+++ b/src/lib/domain/company/models.rs
@@ -1,11 +1,11 @@
 use company_validator::CreateCompany;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub mod company_validator;
 pub mod message;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct Company {
     pub id: uuid::Uuid,
     pub name: Name,
@@ -77,7 +77,7 @@ pub enum CompanyError {
     Unkown(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct Name(String);
 
 #[derive(Clone, Debug, Error)]

--- a/src/lib/domain/company/ports.rs
+++ b/src/lib/domain/company/ports.rs
@@ -30,6 +30,7 @@ pub trait CompanyService: Clone + Send + Sync + 'static {
         &self,
         id: String,
     ) -> impl Future<Output = Result<Option<Company>, CompanyError>> + Send;
+    fn find_all(&self) -> impl Future<Output = Result<Vec<Company>, CompanyError>> + Send;
     fn add_professional_to_company(
         &self,
         company_id: String,

--- a/src/lib/domain/company/services.rs
+++ b/src/lib/domain/company/services.rs
@@ -54,6 +54,10 @@ where
         Ok(company)
     }
 
+    async fn find_all(&self) -> Result<Vec<Company>, CompanyError> {
+        self.company_repository.find_all().await
+    }
+
     async fn add_professional_to_company(
         &self,
         company_id: String,

--- a/src/lib/infrastructure/company/neo4j/company_repository.rs
+++ b/src/lib/infrastructure/company/neo4j/company_repository.rs
@@ -60,7 +60,24 @@ impl CompanyRepository for Neo4jCompanyRepository {
     }
 
     async fn find_all(&self) -> Result<Vec<Company>, CompanyError> {
-        todo!()
+        let query = query("MATCH (c:Company) RETURN c");
+
+        let mut result = self
+            .neo4j
+            .get_graph()
+            .execute(query)
+            .await
+            .map_err(|_| CompanyError::NotFound)?;
+
+        let mut companies = Vec::new();
+        while let Ok(Some(row)) = result.next().await {
+            let company: Company = row
+                .get("c")
+                .map_err(|e| CompanyError::Unkown(e.to_string()))?;
+            companies.push(company);
+        }
+
+        Ok(companies)
     }
 
     async fn find_by_id(&self, id: String) -> Result<Option<Company>, CompanyError> {


### PR DESCRIPTION
## Description
This PR adds two new endpoints for managing `companies`: 

1. Endpoint to retrieve the list of companies
     - Endpoint: `GET /v1/companies`
     - Description: This endpoint is used to retrieve the list of all available companies
     - Handler: `get_companies::<C>`

2. Endpoint to retrieve a company by its ID
     - Endpoint: `GET /companies/:company_id`
     - Description: This endpoint is used to retrieve the details of a specific company using its unique identifier.
     - Handler: `get_company::<C>`